### PR TITLE
Add SweetAlert2 confirmation to delete action

### DIFF
--- a/app/Livewire/Products.php
+++ b/app/Livewire/Products.php
@@ -13,6 +13,7 @@ class Products extends Component
 {
     public $products, $code, $name, $productId;
     public $isEdit = false;
+    protected $listeners = ['deleteProduct' => 'delete'];
 
 
 

--- a/resources/views/livewire/products.blade.php
+++ b/resources/views/livewire/products.blade.php
@@ -36,7 +36,7 @@
                     <td>{{ $product->name }}</td>
                     <td>
                         <button wire:click="edit({{ $product->id }})" class="btn btn-sm btn-warning">Editar</button>
-                        <button wire:click="delete({{ $product->id }})" class="btn btn-sm btn-danger">Eliminar</button>
+                        <button type="button" onclick="confirmDelete({{ $product->id }})" class="btn btn-sm btn-danger">Eliminar</button>
                     </td>
                 </tr>
             @empty
@@ -45,3 +45,22 @@
         </tbody>
     </table>
 </div>
+
+@push('js')
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <script>
+        function confirmDelete(id) {
+            Swal.fire({
+                title: 'Está seguro de eliminar el registro?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Sí, eliminar',
+                cancelButtonText: 'Cancelar'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    Livewire.emit('deleteProduct', id);
+                }
+            });
+        }
+    </script>
+@endpush


### PR DESCRIPTION
## Summary
- add SweetAlert2 popup for deleting products
- handle delete event via Livewire listener

## Testing
- `composer test` *(fails: composer not found)*
- `./vendor/bin/phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684313e100c88321a309a3623241ae81